### PR TITLE
Fix/emacs settings

### DIFF
--- a/.emacs.d/conf.d/init.org
+++ b/.emacs.d/conf.d/init.org
@@ -11,6 +11,10 @@
 
 * 基本設定
 ** 画面系
+*** エンコーディング
+    #+BEGIN_SRC emacs-lisp
+      (setenv "LANG" "ja_JP.UTF-8")
+    #+END_SRC
 *** 背景色
     GUIモードの場合のみ読み込む
     #+BEGIN_SRC emacs-lisp
@@ -25,24 +29,64 @@
 *** 起動時のフレーム設定
     #+BEGIN_SRC emacs-lisp
       (setq initial-frame-alist
-         (append (list
-            '(top . 0)
-            '(left . 70)
-            '(width . 210)
-            '(height . 70))
-           initial-frame-alist))
+            (append
+             '((top . 0)
+               (left . 70)
+               (width . 250)
+               (height . 65))
+             initial-frame-alist))
+      ;; macの場合スクロールバー・タイトルバーを消す
+      (when (memq window-system '(mac ns))
+        (setq initial-frame-alist
+              (append
+               '((ns-transparent-titlebar . t)
+                 (vertical-scroll-bars . nil)
+                 (ns-appearance . dark))
+               initial-frame-alist)))
       (setq default-frame-alist initial-frame-alist)
     #+END_SRC
-
 *** フォント・カーソル設定
-    #+BEGIN_SRC emacs-lisp
-      (if window-system
-          (progn
-            (set-frame-font "-*-Menlo-normal-normal-normal-*-10-*-*-*-m-0-iso10646-1")
-            (set-cursor-color "#525252")
-            (blink-cursor-mode 0)
-            ))
-    #+END_SRC
+**** カーソルの設定
+      #+BEGIN_SRC emacs-lisp
+        (if window-system
+            (progn
+              (set-cursor-color "#525252")
+              (blink-cursor-mode 0)))
+      #+END_SRC
+**** フォントの設定
+      https://qiita.com/gooichi/items/03789492eec26607e11b
+      #+BEGIN_SRC emacs-lisp
+        (when (and (>= emacs-major-version 24) (not (null window-system)))
+          (let* ((font-family "Avenir")
+                 (font-size 10)
+                 (font-height (* font-size 10))
+                 (jp-font-family "Hiragino Maru Gothic ProN"))
+            (set-face-attribute 'default nil :family font-family :height font-height)
+            (let ((name (frame-parameter nil 'font))
+                  (jp-font-spec (font-spec :family jp-font-family))
+                  (jp-characters '(katakana-jisx0201
+                                   cp932-2-byte
+                                   japanese-jisx0212
+                                   japanese-jisx0213-2
+                                   japanese-jisx0213.2004-1))
+                  (font-spec (font-spec :family font-family))
+                  (characters '((?\u00A0 . ?\u00FF)  ; Latin-1
+                                (?\u0100 . ?\u017F)  ; Latin Extended-A
+                                (?\u0180 . ?\u024F)  ; Latin Extended-B
+                                (?\u0250 . ?\u02AF)  ; IPA Extensions
+                                (?\u0370 . ?\u03FF)))); Greek and Coptic
+              (dolist (jp-character jp-characters)
+                (set-fontset-font name jp-character jp-font-spec))
+              (dolist (character characters)
+                (set-fontset-font name character font-spec))
+              (add-to-list 'face-font-rescale-alist (cons font-family 1.0)))))
+      #+END_SRC
+
+**** Dired-modeの場合等幅フォントを利用
+     #+BEGIN_SRC emacs-lisp
+     (set-face-font 'variable-pitch "menlo")
+     (add-hook 'dired-mode-hook 'variable-pitch-mode)
+     #+END_SRC
 
 *** ツールバーを消す
     #+BEGIN_SRC emacs-lisp
@@ -70,7 +114,10 @@
          (let ((proc (start-process "pbcopy" "*Messages*" "pbcopy")))
            (process-send-string proc text)
            (process-send-eof proc))))
+     (defun copy-from-osx ()
+       (shell-command-to-string "pbpaste"))
      (setq interprogram-cut-function 'paste-to-osx)
+     (setq interprogram-paste-function 'copy-from-osx)
    #+END_SRC
 
 *** 折り返し設定

--- a/.emacs.d/conf.d/init.org
+++ b/.emacs.d/conf.d/init.org
@@ -12,6 +12,7 @@
 * 基本設定
 ** 画面系
 *** エンコーディング
+*** encoding
     #+BEGIN_SRC emacs-lisp
       (setenv "LANG" "ja_JP.UTF-8")
     #+END_SRC


### PR DESCRIPTION
フォントの設定を変更
- Mojaveでコピペが文字化けていたのでLANGの設定を追加
- スクロールバー・タイトルバーを削除
- フォントを変更
 + 試験的にプロポーショナルフォントを利用
 + dired-modeの時は、等幅フォントになるように設定を追加